### PR TITLE
Increase maximun allowed line length to 120

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -111,5 +111,6 @@
     // [4]: http://www.jshint.com/options/
 
     "maxerr"        : 100,      // Maximum errors before stopping.
+    "maxlen"        : 120,      // Maximum line length.
     "indent"        : 4         // Specify indentation spacing
 }


### PR DESCRIPTION
By default, jshint understands that if we're not setting a `maxlen`
property, then there should not be an enforced maximun line length.

However, Hound CI merges our specified `jshintrc` with their default
configuration, which includes a `maxlen: 80`. Since we don't declare
this option ourselves, we inherit a maximun of 80 which causes a lots of
unwanted false alarms.